### PR TITLE
Make export hooks work after being cancelled once

### DIFF
--- a/src/export-final
+++ b/src/export-final
@@ -8,5 +8,5 @@ require 'bundler/setup'
 require 'hookit/setup'
 
 execute "send diff data to new member" do
-  command "rsync --delete -a /data/var/db/postgresql/. #{payload[:member][:local_ip]}:/data/var/db/postgresql/"
+  command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -a /data/var/db/postgresql/. #{payload[:member][:local_ip]}:/data/var/db/postgresql/"
 end

--- a/src/redundant-export-final
+++ b/src/redundant-export-final
@@ -12,7 +12,7 @@ payload[:members].each do |member|
   if ["primary", "secondary", "default"].include? member[:role]
 
     execute "send diff data to new member" do
-      command "rsync --delete -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
+      command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
     end
 
   end

--- a/src/templates/run-root.erb
+++ b/src/templates/run-root.erb
@@ -1,4 +1,8 @@
 #!/bin/sh -e
+
+# redirect stderr to stdout
+exec 2>&1
+
 export PATH="/data/sbin:/data/bin:/opt/gonano/sbin:/opt/gonano/bin:/opt/local/sbin:/opt/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 exec <%= exec %>

--- a/src/templates/run.erb
+++ b/src/templates/run.erb
@@ -1,4 +1,8 @@
 #!/bin/sh -e
+
+# redirect stderr to stdout
+exec 2>&1
+
 export PATH="/data/sbin:/data/bin:/opt/gonano/sbin:/opt/gonano/bin:/opt/local/sbin:/opt/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 <%
 if File.exist?('/data/etc/environment.d/nano-envs')

--- a/src/update
+++ b/src/update
@@ -23,8 +23,7 @@ end
 
 if local_md5 != aws_md5
   execute "update hooks" do
-    command <<-END
-bash -c 'curl \
+    command "curl \
     -f \
     -k \
     https://d1ormdui8qdvue.cloudfront.net/hooks/postgresql-#{converged_config[:hook_ref]}.tgz \
@@ -33,7 +32,6 @@ bash -c 'curl \
     -f \
     -k \
     -o /var/nanobox/hooks.md5 \
-    https://d1ormdui8qdvue.cloudfront.net/hooks/postgresql-#{converged_config[:hook_ref]}.md5'
-END
+    https://d1ormdui8qdvue.cloudfront.net/hooks/postgresql-#{converged_config[:hook_ref]}.md5"
   end
 end


### PR DESCRIPTION
If a migration is cancelled, the next one will likely fail, as the old generation would have saved the (deleted) new generation ssh host keys to its own known_hosts database