### PR TITLE
Migrate without config

### DIFF
--- a/src/export-final
+++ b/src/export-final
@@ -14,5 +14,5 @@ if ! `pgrep postgres`.empty?
 end
 
 execute "send diff data to new member" do
-  command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -a /data/var/db/postgresql/. #{payload[:member][:local_ip]}:/data/var/db/postgresql/"
+  command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --exclude=/data/var/db/postgresql/postgresql.conf --exclude=/data/var/db/postgresql/pg_hba.conf -a /data/var/db/postgresql/. #{payload[:member][:local_ip]}:/data/var/db/postgresql/"
 end

--- a/src/export-live
+++ b/src/export-live
@@ -20,5 +20,5 @@ if available_space < needed_space
 end #unless payload[:clear_data] == "false"
 
 execute "send bulk data to new member" do
-  command "tar -cf - /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{payload[:member][:local_ip]} tar -C / -xpf -"
+  command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{payload[:member][:local_ip]} tar -C / -xpf -"
 end

--- a/src/export-live
+++ b/src/export-live
@@ -20,5 +20,5 @@ if available_space < needed_space
 end #unless payload[:clear_data] == "false"
 
 execute "send bulk data to new member" do
-  command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{payload[:member][:local_ip]} tar -C / -xpf -"
+  command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf --exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{payload[:member][:local_ip]} tar -C / -xpf -"
 end

--- a/src/redundant-export-final
+++ b/src/redundant-export-final
@@ -12,7 +12,7 @@ payload[:members].each do |member|
   if ["primary", "secondary", "default"].include? member[:role]
 
     execute "send diff data to new member" do
-      command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
+      command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
     end
 
   end

--- a/src/redundant-export-final
+++ b/src/redundant-export-final
@@ -12,7 +12,7 @@ payload[:members].each do |member|
   if ["primary", "secondary", "default"].include? member[:role]
 
     execute "send diff data to new member" do
-      command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
+      command "rsync --delete -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' --exclude=/data/var/db/postgresql/postgresql.conf --exclude=/data/var/db/postgresql/pg_hba.conf -a /data/var/db/postgresql/. #{member[:local_ip]}:/data/var/db/postgresql/"
     end
 
   end

--- a/src/redundant-export-live
+++ b/src/redundant-export-live
@@ -12,7 +12,7 @@ payload[:members].each do |member|
   if ["primary", "secondary", "default"].include? member[:role]
 
     execute "send bulk data to new member" do
-      command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{member[:local_ip]} tar -xpf -"
+      command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf --exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{member[:local_ip]} tar -xpf -"
     end
 
   end

--- a/src/redundant-export-live
+++ b/src/redundant-export-live
@@ -12,7 +12,7 @@ payload[:members].each do |member|
   if ["primary", "secondary", "default"].include? member[:role]
 
     execute "send bulk data to new member" do
-      command "tar -cf - /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{member[:local_ip]} tar -xpf -"
+      command "tar -cf - --exclude=/data/var/db/postgresql/postgresql.conf -exclude=/data/var/db/postgresql/pg_hba.conf /data/var/db/postgresql | ssh -o StrictHostKeyChecking=no #{member[:local_ip]} tar -xpf -"
     end
 
   end


### PR DESCRIPTION
- Skip the Postgres config when migrating data ￼…
  The config has already been set up by the `configure` hook, so we don't want to override it with incorrect values.

- Skip configs in final migration as well

- Also in the redundant export...

- ... and its finalization.